### PR TITLE
[Feat] 트렌드 게시글 삭제 / 회원 프로필 조회 시 스크랩 게시글 조회 완료

### DIFF
--- a/itty-backend/src/main/java/org/iot/itty/article/controller/TrendArticleController.java
+++ b/itty-backend/src/main/java/org/iot/itty/article/controller/TrendArticleController.java
@@ -13,7 +13,9 @@ import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -53,5 +55,14 @@ public class TrendArticleController {
 			result.put("message", "There is no new trend article to add.");
 		}
 		return ResponseEntity.status(HttpStatus.CREATED).body(result);
+	}
+
+	@DeleteMapping("/article/trend/{trendArticleCodePk}/delete")
+	public ResponseEntity<Map<String, String>> deleteTrendArticle(@PathVariable("trendArticleCodePk") int trendArticleCodePk) {
+		String returnedMessage = trendArticleService.deleteTrendArticle(trendArticleCodePk);
+
+		Map<String, String> result = new HashMap<>();
+		result.put("message", returnedMessage);
+		return ResponseEntity.status(HttpStatus.OK).body(result);
 	}
 }

--- a/itty-backend/src/main/java/org/iot/itty/article/service/TrendArticleService.java
+++ b/itty-backend/src/main/java/org/iot/itty/article/service/TrendArticleService.java
@@ -10,4 +10,6 @@ public interface TrendArticleService {
 	List<TrendArticleDTO> selectAllTrendArticle();
 
 	List<TrendArticleDTO> addTrendArticle() throws IOException, ParseException;
+
+	String deleteTrendArticle(int trendArticleCodePk);
 }

--- a/itty-backend/src/main/java/org/iot/itty/article/service/TrendArticleServiceImpl.java
+++ b/itty-backend/src/main/java/org/iot/itty/article/service/TrendArticleServiceImpl.java
@@ -84,4 +84,14 @@ public class TrendArticleServiceImpl implements TrendArticleService{
 			.map(TrendArticleEntity -> modelMapper.map(TrendArticleEntity, TrendArticleDTO.class))
 			.toList();
 	}
+
+	@Override
+	public String deleteTrendArticle(int trendArticleCodePk) {
+		try {
+			trendArticleRepository.deleteById(trendArticleCodePk);
+			return "Successfully deleted trend article.";
+		} catch (Exception e) {
+			return "Failed to delete trend article.";
+		}
+	}
 }

--- a/itty-backend/src/main/java/org/iot/itty/dto/UserDTO.java
+++ b/itty-backend/src/main/java/org/iot/itty/dto/UserDTO.java
@@ -6,6 +6,7 @@ import org.iot.itty.article.vo.ResponseSelectAllArticleByUserCodeFk;
 import org.iot.itty.article.vo.ResponseSelectAllArticleLikedByUserCodeFk;
 import org.iot.itty.article.vo.ResponseSelectAllReplyByUserCodeFk;
 import org.iot.itty.article.vo.ResponseSelectAllReplyLikedByUserCodeFk;
+import org.iot.itty.article.vo.ResponseSelectAllScrapByUserCodeFk;
 
 import lombok.Data;
 
@@ -24,4 +25,5 @@ public class UserDTO {
 	private List<ResponseSelectAllReplyByUserCodeFk> replyDTOList;
 	private List<ResponseSelectAllArticleLikedByUserCodeFk>likedArticleDTOList;
 	private List<ResponseSelectAllReplyLikedByUserCodeFk> likedReplyDTOList;
+	private List<ResponseSelectAllScrapByUserCodeFk> scrappedTrendArticleDTOList;
 }

--- a/itty-backend/src/main/java/org/iot/itty/user/controller/UserController.java
+++ b/itty-backend/src/main/java/org/iot/itty/user/controller/UserController.java
@@ -5,12 +5,15 @@ import java.util.List;
 import org.iot.itty.article.service.ArticleService;
 import org.iot.itty.article.service.LikeService;
 import org.iot.itty.article.service.ReplyService;
+import org.iot.itty.article.service.ScrapService;
 import org.iot.itty.article.vo.ResponseSelectAllArticleByUserCodeFk;
 import org.iot.itty.article.vo.ResponseSelectAllArticleLikedByUserCodeFk;
 import org.iot.itty.article.vo.ResponseSelectAllReplyByUserCodeFk;
 import org.iot.itty.article.vo.ResponseSelectAllReplyLikedByUserCodeFk;
+import org.iot.itty.article.vo.ResponseSelectAllScrapByUserCodeFk;
 import org.iot.itty.dto.ArticleDTO;
 import org.iot.itty.dto.ReplyDTO;
+import org.iot.itty.dto.TrendArticleDTO;
 import org.iot.itty.dto.UserDTO;
 import org.iot.itty.user.service.UserService;
 import org.iot.itty.user.vo.RequestUserModify;
@@ -36,6 +39,7 @@ public class UserController {
 	private final ArticleService articleService;
 	private final ReplyService replyService;
 	private final LikeService likeService;
+	private final ScrapService scrapService;
 
 	@Autowired
 	public UserController(
@@ -43,7 +47,8 @@ public class UserController {
 		UserService userService,
 		ArticleService articleService,
 		ReplyService replyService,
-		LikeService likeService
+		LikeService likeService,
+		ScrapService scrapService
 	)
 	{
 		this.modelMapper = modelMapper;
@@ -51,6 +56,7 @@ public class UserController {
 		this.articleService = articleService;
 		this.replyService = replyService;
 		this.likeService = likeService;
+		this.scrapService = scrapService;
 	}
 
 	/* 회원별 회원정보 조회 */
@@ -86,10 +92,18 @@ public class UserController {
 				.map(ReplyDTO -> modelMapper.map(ReplyDTO, ResponseSelectAllReplyLikedByUserCodeFk.class))
 				.toList();
 
+		/* 해당 회원이 스크랩한 트렌드 게시글 리스트 가져오기 */
+		List<ResponseSelectAllScrapByUserCodeFk> responseSelectAllScrapByUserCodeFkList =
+			scrapService.selectAllScrapByUserCodeFk(userCodePk)
+				.stream()
+				.map(TrendArticleDTO -> modelMapper.map(TrendArticleDTO, ResponseSelectAllScrapByUserCodeFk.class))
+				.toList();
+
 		userDTO.setArticleDTOList(responseSelectAllArticleByUserCodeFkList);
 		userDTO.setReplyDTOList(responseSelectAllReplyByUserCodeFkList);
 		userDTO.setLikedArticleDTOList(responseSelectAllArticleLikedByUserCodeFkList);
 		userDTO.setLikedReplyDTOList(responseSelectAllReplyLikedByUserCodeFkList);
+		userDTO.setScrappedTrendArticleDTOList(responseSelectAllScrapByUserCodeFkList);
 		return ResponseEntity.status(HttpStatus.OK).body(modelMapper.map(userDTO, ResponseSelectUserByUserCodePk.class));
 	}
 

--- a/itty-backend/src/main/java/org/iot/itty/user/vo/ResponseSelectUserByUserCodePk.java
+++ b/itty-backend/src/main/java/org/iot/itty/user/vo/ResponseSelectUserByUserCodePk.java
@@ -6,6 +6,7 @@ import org.iot.itty.article.vo.ResponseSelectAllArticleByUserCodeFk;
 import org.iot.itty.article.vo.ResponseSelectAllArticleLikedByUserCodeFk;
 import org.iot.itty.article.vo.ResponseSelectAllReplyByUserCodeFk;
 import org.iot.itty.article.vo.ResponseSelectAllReplyLikedByUserCodeFk;
+import org.iot.itty.article.vo.ResponseSelectAllScrapByUserCodeFk;
 
 import lombok.Data;
 
@@ -24,4 +25,5 @@ public class ResponseSelectUserByUserCodePk {
 	private List<ResponseSelectAllReplyByUserCodeFk> replyDTOList;
 	private List<ResponseSelectAllArticleLikedByUserCodeFk>likedArticleDTOList;
 	private List<ResponseSelectAllReplyLikedByUserCodeFk> likedReplyDTOList;
+	private List<ResponseSelectAllScrapByUserCodeFk> scrappedTrendArticleDTOList;
 }


### PR DESCRIPTION
## 개요
1. 트렌드 게시글 삭제
왜 : 불필요하게 크롤링된 트렌드 게시글을 DB에서 삭제하기 위해 
무엇을 : 트렌드 게시글 DB에서 삭제 기능 구현 완료

2. 회원 프로필 조회 시 스크랩 게시글 조회
왜 : 회원 프로필 조회 기능 중 일부인 해당 회원의 스크랩 게시글 조회를 위해
무엇을 : 회원 프로필 조회 시 스크랩 게시글 조회 기능 구현 완료

## 관련 이슈
Resolves: #23 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
